### PR TITLE
Fixes for Xcode and Project Generator

### DIFF
--- a/addons.make
+++ b/addons.make
@@ -1,2 +1,0 @@
-ofxGui
-ofxImageSegmentation

--- a/addons.make
+++ b/addons.make
@@ -1,0 +1,2 @@
+ofxGui
+ofxImageSegmentation

--- a/example-ImageSegmentation/addons.make
+++ b/example-ImageSegmentation/addons.make
@@ -1,0 +1,2 @@
+ofxGui
+ofxImageSegmentation

--- a/libs/egs/convolve.h
+++ b/libs/egs/convolve.h
@@ -18,8 +18,8 @@ static void convolve_even(image11<float> *src, image11<float> *dst,
       float sum = mask[0] * imRef(src, x, y);
       for (int i = 1; i < len; i++) {
 	sum += mask[i] * 
-	  (imRef(src, __max(x-i,0), y) + 
-	   imRef(src, __min(x+i, width-1), y));
+	  (imRef(src, max(x-i,0), y) + 
+	   imRef(src, min(x+i, width-1), y));
       }
       imRef(dst, y, x) = sum;
     }
@@ -38,8 +38,8 @@ static void convolve_odd(image11<float> *src, image11<float> *dst,
       float sum = mask[0] * imRef(src, x, y);
       for (int i = 1; i < len; i++) {
 	sum += mask[i] * 
-	  (imRef(src, __max(x-i,0), y) - 
-	   imRef(src, __min(x+i, width-1), y));
+	  (imRef(src, max(x-i,0), y) - 
+	   imRef(src, min(x+i, width-1), y));
       }
       imRef(dst, y, x) = sum;
     }

--- a/libs/egs/filter.h
+++ b/libs/egs/filter.h
@@ -27,7 +27,7 @@ static void normalize(std::vector<float> &mask) {
 /* make filters */
 #define MAKE_FILTER(name, fun)                                \
 static std::vector<float> make_ ## name (float sigma) {       \
-  sigma = __max(sigma, 0.01F);			      \
+  sigma = max(sigma, 0.01F);			      \
   int len = (int)ceil(sigma * WIDTH) + 1;                     \
   std::vector<float> mask(len);                               \
   for (int i = 0; i < len; i++) {                             \


### PR DESCRIPTION
These double underscores were being read as undeclared identifiers. Also made an addons.make for Project Generator for the example folder. Tested in OpenFrameworks v0.9.0, OS X 10.11.3, Xcode 7.2.1.
